### PR TITLE
Handle options.regex of type regular expression

### DIFF
--- a/jquery.filter_input.js
+++ b/jquery.filter_input.js
@@ -56,7 +56,9 @@
               return true;
             } else if (event.type=='after_paste') {
               var string = input.val();
-              var regex = new RegExp('^('+options.regex+')+$');
+              // If options.regex is a regular expression, grab the source. If it's a string use it as is
+              var regexString = (typeof options.regex === 'string' ? options.regex : options.regex.source);
+              var regex = new RegExp('^('+regexString+')+$');
             } else {
               return false;
             }


### PR DESCRIPTION
If `options.regex` is of type `RegExp`, extract the source before inserting it into a new `RegExp`, otherwise matching fails.

Example, that fails without this fix, but works afterwards:

```
$('[name="text"]').filter_input({regex: /[\d\w]/});
```
